### PR TITLE
Change trigger value to 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ app.get('/uncaught', (req, res) => {
 //Generates an uncaught exception every 1000 requests
 app.get('/random-error', (req, res) => {
   let errorNum = (Math.floor(Math.random() * 1000) + 1);
-  if (errorNum==13) {
+  if (errorNum==1) {
     console.log("Called /random-error, and it's about to error");
     doesNotExist();
   }


### PR DESCRIPTION
13 is arbitrary, but had students updating probability from 1 in 1000 to 1 in 10 and finding the errors not triggering because it would never hit 13.  Setting the trigger number to 1 would not change probability but would make the 1 in x intuitive.